### PR TITLE
Fixed NAV 2018 auto update

### DIFF
--- a/Scripts/AdvaniaGIT/Download-LatestNAVUpdate.ps1
+++ b/Scripts/AdvaniaGIT/Download-LatestNAVUpdate.ps1
@@ -17,7 +17,7 @@
         Write-Host "Downloading CU information from Microsoft Blog..."
         $pageId = 1
         while (!$DownloadUrls) {
-            $DownloadUrls = Get-LatestCUDownloadUrls -SetupParameters $SetupParameters -FeedUrl "https://blogs.msdn.microsoft.com/nav/feed/atom/?paged=$pageId"
+            $DownloadUrls = Get-LatestCUDownloadUrls -SetupParameters $SetupParameters -FeedUrl "https://support.microsoft.com/app/content/api/content/feeds/sap/en-gb/dea12e4a-4dd3-35e1-2577-45df252a2b9c/atom"
             if ($pageId -gt 10) { 
                 Write-Host -ForegroundColor Red "Download Urls for $($SetupParameters.navRelease) not found!"
                 throw

--- a/Scripts/AdvaniaGIT/Get-LatestCUDownloadUrls.ps1
+++ b/Scripts/AdvaniaGIT/Get-LatestCUDownloadUrls.ps1
@@ -11,25 +11,41 @@
     # Download RSS Feed
     $FeedFilePath = (Join-Path $SetupParameters.LogPath "Feed.xml")
     $ArticlePath = (Join-Path $SetupParameters.LogPath "Article.html")
+    $DownloadPagePath = (Join-Path $SetupParameters.LogPath "Download.html")
     Download-NAVFile -Url $FeedUrl -FileName $FeedFilePath
     [xml]$Content = Get-Content $FeedFilePath 
     $Feed = $Content.feed
 
     $DownloadUrls = @()
-    $SearchString = "Cumulative Update * for Microsoft Dynamics NAV $($SetupParameters.navRelease) has been released"
+    $SearchString = "Cumulative Update * for Microsoft Dynamics NAV $($SetupParameters.navRelease) *"
     ForEach ($item in $Feed.entry){ 
-        Write-Verbose "Found article $($item.title.InnerText)..."
+        Write-Verbose "Found article $($item.title)..."
 
-        if ($item.title.InnerText -like $SearchString) {
-            Download-NAVFile -Url $item.link.Item(0).href -FileName $ArticlePath
-            $Article = (Get-Content $ArticlePath | Out-String).Replace("<span>","")
+        if ($item.title -like $SearchString) {
+            Download-NAVFile -Url $item.link.href -FileName $ArticlePath
+            $Article = (Get-Content $ArticlePath | Out-String).Replace("<span>","")			
             $endPos = 1
-            while ($Article.IndexOf("http://download.microsoft.com/download", $endPos) -gt 0) {
-                $startPos = $Article.IndexOf('http://download.microsoft.com/download', $endPos)
-                $endPos = $Article.IndexOf('">', $startPos)
-                $cuLink = $Article.Substring($startPos, $endPos - $startPos)
-                $cuLocal = $Article.Substring($endPos + 2, 2)
-                $DownloadUrls += @{"LocalVersion"=$cuLocal; "DownloadUrl"=$cuLink}
+            if ($Article.IndexOf("http://www.microsoft.com/downloads/details.aspx?familyid=", $endPos) -gt 0) {
+                $startPos = $Article.IndexOf('http://www.microsoft.com/downloads/details.aspx?familyid=', $endPos)
+                $endPos = $Article.IndexOf('\"', $startPos)
+                $DownloadUrl = $Article.Substring($startPos, $endPos - $startPos)    
+
+                Download-NAVFile -Url $DownloadUrl -FileName $DownloadPagePath
+                $DownloadPage = Get-Content $DownloadPagePath | Out-String
+                $endPos = 1
+                $startPos = $DownloadPage.IndexOf("confirmation.aspx?id=", $endPos)
+                $endPos = $DownloadPage.IndexOf('" ', $startPos)
+                $DownloadUrl = 'https://www.microsoft.com/en-us/download/' + $DownloadPage.Substring($startPos, $endPos - $startPos)
+
+                Download-NAVFile -Url $DownloadUrl -FileName $DownloadPagePath
+                $DownloadPage = Get-Content $DownloadPagePath | Out-String
+                $endPos = 1
+                $startPos = $DownloadPage.IndexOf('base_0:{url:"', $endPos)
+                $endPos = $DownloadPage.IndexOf('/CU', $startPos) 
+                $cuNumber = $item.title.Substring(18,2)             
+                $DownloadUrl = ($DownloadPage.Substring($startPos, $endPos - $startPos)).Replace('base_0:{url:"','') + '/CU ' + $cuNumber + ' NAV 2018 ' + $SetupParameters.navSolution + '.zip' 
+                            
+                $DownloadUrls += @{"LocalVersion"=($SetupParameters.navSolution); "DownloadUrl"=$DownloadUrl}
             }
             return $DownloadUrls
         }


### PR DESCRIPTION
- Added new feed url generated from Microsoft support content update

- Changed script to download latest CU for NAV 2018
