### PR TITLE
Copy Add-ins as per NAVContainerHelper

### DIFF
--- a/Scripts/AdvaniaGIT/Start-DockerContainer.ps1
+++ b/Scripts/AdvaniaGIT/Start-DockerContainer.ps1
@@ -62,6 +62,12 @@
                 "--env SqlTimeout=1200",
                 "--dns 8.8.8.8")
 
+    $branchAddInsFolder = "$($SetupParameters.Repository)\Add-Ins"
+    if (Test-Path -Path $branchAddInsFolder -PathType Container ) { 
+        $branchAddInsFolder = "$($SetupParameters.Repository)\Add-Ins:c:\run\Add-Ins"
+        $parameters += @("--volume `"$branchAddInsFolder`"")
+    }
+
     if ($SetupParameters.BuildMode) {
         $parameters += @("--env webClient=N",
                          "--env httpSite=N")        


### PR DESCRIPTION
In order to correctly copy the Add-Ins to the service tier, I have added copying the <Repository>/Add-Ins folder, if exists, to the c:\run\Add-Ins. NAVContainerHelper then automatically copies to the Client and the Service Tier.