### PR TITLE
Add Restart Always and Map Add-Ins: mapAddInFolder

### DIFF
--- a/Scripts/AdvaniaGIT/Start-DockerContainer.ps1
+++ b/Scripts/AdvaniaGIT/Start-DockerContainer.ps1
@@ -60,13 +60,26 @@
                 "--volume `"$volume`"",
                 "--volume `"$rootPath`"",
                 "--env SqlTimeout=1200",
-                "--dns 8.8.8.8")
+                "--dns 8.8.8.8",
+                "--restart always")
 
 
     if ([int]($SetupParameters.navVersion).split(".")[0] -lt 15) {
         if ($SetupParameters.BuildMode) {
             $parameters += @("--env webClient=N",
                              "--env httpSite=N")        
+        }
+    }
+
+    if ([int]($SetupParameters.navVersion).split(".")[0] -lt 15) {
+        if (![System.String]::IsNullOrEmpty($SetupParameters.mapAddInFolder)) {
+            $branchAddInsFolder = "$($SetupParameters.Repository)\Add-Ins"
+            if (Test-Path -Path $branchAddInsFolder -PathType Container ) { 
+                $branchAddInsFolder = "$($SetupParameters.Repository)\Add-Ins:c:\run\Add-Ins"
+                $parameters += @(
+                                    "--volume `"$branchAddInsFolder`""
+                                )
+            }
         }
     }
 


### PR DESCRIPTION
Having to deal with containers crashing, research shows that adding `--restart always` to the parameters should help with that: https://dynamicsuser.net/nav/f/technical/94723/docker-container-is-unhealthy---what-to-do

Also re-adding the mapping of the Add-ins folder for non-bc containers. this time based on a setup `mapAddInFolder`